### PR TITLE
bugfix on the inherited IVs function

### DIFF
--- a/src/daycare.c
+++ b/src/daycare.c
@@ -560,8 +560,9 @@ static void InheritIVs(struct Pokemon *egg, struct DayCare *daycare)
     for (i = 0; i < inheritedIvCount; i++)
     {
         // Randomly pick an IV from the available list and stop from being chosen again.
-        selectedIvs[i] = availableIVs[Random() % (NUM_STATS - i)];
-        RemoveIVIndexFromList(availableIVs, i);
+        u8 availableIVsIndex = Random() % (NUM_STATS - i);
+        selectedIvs[i] = availableIVs[availableIVsIndex];
+        RemoveIVIndexFromList(availableIVs, availableIVsIndex);
     }
 
     // Determine which parent each of the selected IVs should inherit from.


### PR DESCRIPTION
when selecting the random IVs to be inherited, the code was supposed to remove the current IV from the list. Instead, it was removing the IV of the current index of the iteration os status